### PR TITLE
adjustment to bootstrap signature

### DIFF
--- a/src/main/scala/zio/test/akkahttp/AkkaZIOSpecDefault.scala
+++ b/src/main/scala/zio/test/akkahttp/AkkaZIOSpecDefault.scala
@@ -5,7 +5,7 @@ import zio.test.{testEnvironment, Spec, TestEnvironment, ZIOSpec}
 
 trait AkkaZIOSpecDefault extends ZIOSpec[RouteTestEnvironment.TestEnvironment with TestEnvironment] with RouteTest {
 
-  override val bootstrap: ZLayer[Scope, Any, RouteTestEnvironment.TestEnvironment with TestEnvironment] =
+  override val bootstrap: ZLayer[Any, Any, RouteTestEnvironment.TestEnvironment with TestEnvironment] =
     testEnvironment >+> RouteTestEnvironment.environment
 
   def spec: Spec[RouteTestEnvironment.TestEnvironment with TestEnvironment with Scope, Any]


### PR DESCRIPTION
In the current zio snapshot, bootstrap in ZIOSpecAbstract is a 
```
def bootstrap: ZLayer[Any, Any, Environment]
```